### PR TITLE
Corrected Puppet lint/syntax issues.

### DIFF
--- a/manifests/yumrepo.pp
+++ b/manifests/yumrepo.pp
@@ -35,12 +35,12 @@
 #
 define repoforge::yumrepo (
   $repos,
-  $repo_shortname = $name,
   $baseurl,
   $mirrorlist,
   $enabled,
   $includepkgs,
   $exclude,
+  $repo_shortname = $name,
 ) {
   $reponame = $repos[$title]
 


### PR DESCRIPTION
Corrected puppet lint issues 
puppet/modules/repoforge/manifests/yumrepo.pp - WARNING: optional parameter listed before required parameter on line 38
